### PR TITLE
Add header- parameter to add-url

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -13,3 +13,4 @@ profiles:
           until: "2021-12-31T00:00:00Z"
         - name: "add-url"
           url: "https://othersource.com/othercalendar.ics"
+          header-Cookie: "MY_AUTH_COOKIE=abcdefgh"

--- a/modules.go
+++ b/modules.go
@@ -122,24 +122,6 @@ func addEvents(cal1 *ics.Calendar, cal2 *ics.Calendar) int {
 	return count
 }
 
-func GetWithXForwardedHeaders(url string, r *http.Request) (*http.Response, error) {
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-	if r.Header.Get("X-Forwarded-Host") != "" {
-		req.Header.Set("X-Forwarded-Host", r.Header.Get("X-Forwarded-Host"))
-	} else {
-		req.Header.Set("X-Forwarded-Host", r.Host)
-	}
-	if r.Header.Get("X-Forwarded-Proto") != "" {
-		req.Header.Set("X-Forwarded-Proto", r.Header.Get("X-Forwarded-Proto"))
-	} else {
-		req.Header.Set("X-Forwarded-Proto", "http") // <- this package has no HTTPS support, so we just assume HTTP
-	}
-	return http.DefaultClient.Do(req)
-}
-
 func moduleAddURL(cal *ics.Calendar, params map[string]string) (int, error) {
 	if params["url"] == "" {
 		return 0, fmt.Errorf("Missing mandatory Parameter 'url'")


### PR DESCRIPTION
Any parameters starting with "header-" for the "add-url" module will now be added as http headers. An example has been added to the example config.yml.