### PR TITLE
Module expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ profiles:
       regex: "testentry"
       from: "2021-12-02T00:00:00Z"
       until: "2021-12-31T00:00:00Z"
+      expires: "2022-12-06T00:00:00Z"
     - name: "add-url"
       url: "https://othersource.com/othercalendar.ics"
       header-Cookie: "MY_AUTH_COOKIE=abcdefgh"
@@ -78,6 +79,8 @@ The modules are executed in the order they are listed and you can call a module 
 # Modules
 
 Feel free do open a PR with modules of your own.
+
+Adding `expires: <RFC3339>` to any module will remove it on the next cleanup cycle after the date has passed. Currently the Cleanup runs every 1h.
 
 ## immutable-past
 

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -180,4 +181,39 @@ func (c Config) addModule(profile string, module map[string]string) error {
 	p.Modules = append(c.Profiles[profile].Modules, module)
 	c.Profiles[profile] = p
 	return c.saveConfig(configPath)
+}
+
+func (c Config) RunCleanup() {
+	for p := range c.Profiles {
+		for i, m := range c.Profiles[p].Modules {
+			if m["expires"] != "" {
+				exp, _ := time.Parse(time.RFC3339, m["expiration"])
+				if time.Now().After(exp) {
+					log.Info("Removing expired module " + m["name"] + " at position " + fmt.Sprint(i+1) + " from profile " + p)
+					removeFromMapString(c.Profiles[p].Modules, i)
+				}
+			}
+		}
+	}
+	c.saveConfig(configPath)
+}
+
+// starts a heartbeat notifier in a sub-routine
+func CleanupStartup() {
+	log.Info("Starting Cleanup Timer")
+	go TimeCleanup()
+}
+
+func TimeCleanup() {
+	interval, _ := time.ParseDuration("1h")
+	if interval == 0 {
+		// failsave for 0s interval, to make machine still responsive
+		interval = 1 * time.Second
+	}
+	log.Debug("Cleanup Timer, Interval: " + interval.String())
+	// endless loop
+	for {
+		time.Sleep(interval)
+		conf.RunCleanup()
+	}
 }

--- a/config.yml.example
+++ b/config.yml.example
@@ -21,6 +21,7 @@ profiles:
       regex: "testentry"
       from: "2021-12-02T00:00:00Z"
       until: "2021-12-31T00:00:00Z"
+      expires: "2022-12-31T00:00:00Z"
     - name: "add-url"
       url: "https://othersource.com/othercalendar.ics"
       header-Cookie: "MY_AUTH_COOKIE=abcdefgh"

--- a/helpers.go
+++ b/helpers.go
@@ -92,3 +92,23 @@ func validMail(email string) bool {
 	_, err := mail.ParseAddress(email)
 	return err == nil
 }
+
+// returns true, if a is in list b
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+// https://stackoverflow.com/a/37335777/9397749
+// removes the element at index i from ics.Component slice
+// warning: if you iterate over []ics.Component forward, this removeFromICS will lead to mistakes. Iterate backwards instead!
+func removeFromICS(slice []ics.Component, s int) []ics.Component {
+	return append(slice[:s], slice[s+1:]...)
+}
+func removeFromMapString(slice []map[string]string, s int) []map[string]string {
+	return append(slice[:s], slice[s+1:]...)
+}

--- a/main.go
+++ b/main.go
@@ -65,6 +65,8 @@ func main() {
 
 	// start notifiers
 	NotifierStartup()
+	// start cleanup
+	CleanupStartup()
 
 	// start server
 	address := conf.Server.Addr

--- a/modules.go
+++ b/modules.go
@@ -89,7 +89,7 @@ func removeByRegexSummaryAndTime(cal *ics.Calendar, regex regexp.Regexp, start t
 				// event is in time range
 				if regex.MatchString(event.GetProperty(ics.ComponentPropertySummary).Value) {
 					// event matches regex
-					cal.Components = remove(cal.Components, i)
+					cal.Components = removeFromICS(cal.Components, i)
 					log.Debug("Excluding event '" + event.GetProperty(ics.ComponentPropertySummary).Value + "' with id " + event.Id() + "\n")
 					count--
 				}
@@ -115,7 +115,7 @@ func moduleDeleteId(cal *ics.Calendar, params map[string]string) (int, error) {
 		case *ics.VEvent:
 			event := component.(*ics.VEvent)
 			if event.Id() == params["id"] {
-				cal.Components = remove(cal.Components, i)
+				cal.Components = removeFromICS(cal.Components, i)
 				count--
 				log.Debug("Excluding event with id " + params["id"] + "\n")
 				break
@@ -282,7 +282,7 @@ func moduleDeleteTimeframe(cal *ics.Calendar, params map[string]string) (int, er
 			event := cal.Components[i].(*ics.VEvent)
 			date, _ := event.GetStartAt()
 			if date.After(after) && before.After(date) {
-				cal.Components = remove(cal.Components, i)
+				cal.Components = removeFromICS(cal.Components, i)
 				count--
 				log.Debug("Excluding event with id " + event.Id() + "\n")
 			}
@@ -308,7 +308,7 @@ func moduleDeleteDuplicates(cal *ics.Calendar, params map[string]string) (int, e
 			end, _ := event.GetEndAt()
 			identifier := start.String() + end.String() + event.GetProperty(ics.ComponentPropertySummary).Value
 			if stringInSlice(identifier, uniques) {
-				cal.Components = remove(cal.Components, i)
+				cal.Components = removeFromICS(cal.Components, i)
 				count--
 				log.Debug("Excluding event with id " + event.Id() + "\n")
 			} else {
@@ -583,20 +583,4 @@ func moduleAddAllReminder(cal *ics.Calendar, params map[string]string) (int, err
 		}
 	}
 	return 0, nil
-}
-
-// removes the element at index i from ics.Component slice
-// warning: if you iterate over []ics.Component forward, this remove will lead to mistakes. Iterate backwards instead!
-func remove(slice []ics.Component, s int) []ics.Component {
-	return append(slice[:s], slice[s+1:]...)
-}
-
-// returns true, if a is in list b
-func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Adding `expires: <RFC3339>` to a module will remove it on the next cleanup after the date has passed. Currently the Cleanup runs every 1h.