### PR TITLE
Fix missing template storagePath handling

### DIFF
--- a/config.go
+++ b/config.go
@@ -80,7 +80,7 @@ func ParseConfig(path string) (Config, error) {
 	if tmpConfig.Server.StoragePath == "" {
 		tmpConfig.Server.StoragePath = filepath.Dir(path)
 	}
-	if strings.HasSuffix(tmpConfig.Server.StoragePath, "/") {
+	if !strings.HasSuffix(tmpConfig.Server.StoragePath, "/") {
 		tmpConfig.Server.StoragePath += "/"
 	}
 

--- a/handlers.go
+++ b/handlers.go
@@ -11,8 +11,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var templatePath = "/etc/ical-relay/templates/"
-var htmlTemplates = template.Must(template.ParseGlob(templatePath + "*.html"))
+var templatePath string
+var htmlTemplates *template.Template
 
 type eventData map[string]interface{}
 type calendarDataByDay map[string][]eventData

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"html/template"
 	"net/http"
 	"os"
 
@@ -46,6 +47,10 @@ func main() {
 	} else {
 		log.Debug("Server mode.")
 	}
+
+	// setup template path
+	templatePath = conf.Server.StoragePath + "templates/"
+	htmlTemplates = template.Must(template.ParseGlob(templatePath + "*.html"))
 
 	// setup routes
 	router = mux.NewRouter()


### PR DESCRIPTION
The storagePath was ignored for templates (and the template path was hardcoded to /etc/ical-relay/templates)
There's also a small fix for the config parsing of storagePath