### PR TITLE
Invert colors for "today" VStack

### DIFF
--- a/templates/static/css/main.css
+++ b/templates/static/css/main.css
@@ -11,8 +11,14 @@ body {
 }
 
 .day-column > :first-child {
+    border: 2px solid var(--dhbw-red);
     background-color: var(--dhbw-red);
     color: var(--day-title-color);
+}
+
+.day-column > .today {
+    background-color: var(--day-title-color);
+    color: var(--dhbw-red);
 }
 
 .day-column > :last-child {

--- a/templates/static/js/calendar.js
+++ b/templates/static/js/calendar.js
@@ -57,6 +57,9 @@ function getDayVStack(date, events, show_edit = false) {
     day_vstack.classList.add("vstack", "col-md-4", "col-xl-2", "pt-2", "day-column", "mb-3");
     let day_title = document.createElement("h5");
     day_title.classList.add("fw-semibold", "text-center", "m-0");
+    if (date.isSame(dayjs(), "day")) {
+        day_title.classList.add("today");
+    }
     day_title.innerText = date.format("dd, DD.MM.YYYY");
     day_vstack.appendChild(day_title);
 


### PR DESCRIPTION
Closes #143

![image](https://user-images.githubusercontent.com/18506129/231868906-2e3c8bea-2911-459c-b84f-9aaa3aa03ebe.png)

This also increases the height of *all* titles by 4px, so that the added border on the "today" title does not cause it to be larger than the others.