### PR TITLE
add URL encoding to notifier Mails

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"time"
 
@@ -79,7 +80,7 @@ func notifyChanges(id string, n *notifier) error {
 			m.SetHeader("To", recipient)
 			m.SetHeader("Subject", "Calendar Notification for "+id)
 
-			unsubscribeURL := conf.Server.URL + "/notifier/" + id + "/unsubscribe?mail=" + recipient
+			unsubscribeURL := conf.Server.URL + "/notifier/" + url.QueryEscape(id) + "/unsubscribe?mail=" + url.QueryEscape(recipient)
 			m.SetHeader("List-Unsubscribe", unsubscribeURL)
 			bodyunsubscribe := body + "\n\nUnsubscribe: " + unsubscribeURL
 			m.SetBody("text/plain", string(bodyunsubscribe))


### PR DESCRIPTION
Uses Native Go Library net/url

![Screenshot_20230420_131526_Outlook.jpg](https://user-images.githubusercontent.com/41118534/233350940-06f00d6a-927f-45a5-a7d0-03e8c645cedb.jpg)