### PR TITLE
Weekly view added, renamed monthly->calendar

### DIFF
--- a/cmd/ical-relay/handlers.go
+++ b/cmd/ical-relay/handlers.go
@@ -20,7 +20,7 @@ type calendarDataByDay map[string][]eventData
 func initHandlers() {
 	router.HandleFunc("/", indexHandler)
 	router.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir(conf.Server.TemplatePath+"static/"))))
-	router.HandleFunc("/view/{profile}/monthly", monthlyViewHandler).Name("monthlyView")
+	router.HandleFunc("/view/{profile}", calendarViewHandler).Name("calendarView")
 	router.HandleFunc("/view/{profile}/edit/{uid}", editViewHandler).Name("editView")
 	router.HandleFunc("/view/{profile}/edit", rulesViewHandler).Name("rulesView")
 	router.HandleFunc("/notifier/{notifier}/subscribe", notifierSubscribeHandler).Name("notifierSubscribe")
@@ -137,10 +137,10 @@ func rulesViewHandler(w http.ResponseWriter, r *http.Request) {
 	htmlTemplates.ExecuteTemplate(w, "rules.html", data)
 }
 
-func monthlyViewHandler(w http.ResponseWriter, r *http.Request) {
+func calendarViewHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	requestLogger := log.WithFields(log.Fields{"client": GetIP(r), "profile": vars["profile"]})
-	requestLogger.Infoln("monthly view request")
+	requestLogger.Infoln("calendar view request")
 	profileName := vars["profile"]
 	profile, ok := conf.Profiles[profileName]
 	if !ok {
@@ -158,7 +158,7 @@ func monthlyViewHandler(w http.ResponseWriter, r *http.Request) {
 	data["ProfileName"] = profileName
 	data["Events"] = allEvents
 	data["ImmutablePast"] = profile.ImmutablePast
-	htmlTemplates.ExecuteTemplate(w, "monthly.html", data)
+	htmlTemplates.ExecuteTemplate(w, "calendar.html", data)
 }
 
 func getEventsByDay(calendar *ics.Calendar, profileName string) calendarDataByDay {

--- a/cmd/ical-relay/profiles.go
+++ b/cmd/ical-relay/profiles.go
@@ -27,7 +27,7 @@ func getProfilesMetadata() []profileMetadata {
 	for name, this_profile := range conf.Profiles {
 		if this_profile.Public {
 			// FIXME: any name with "/" will break the URL
-			viewUrl, err := router.Get("monthlyView").URL("profile", name)
+			viewUrl, err := router.Get("calendarView").URL("profile", name)
 			if err != nil {
 				log.Errorln(err)
 				continue

--- a/cmd/ical-relay/templates/calendar.html
+++ b/cmd/ical-relay/templates/calendar.html
@@ -4,7 +4,6 @@
     {{template "head.html" .}}
     <script src="/static/js/calendar.js"></script>
 </head>
-
 <body>
     {{template "nav.html" .}}
     <main class="container">
@@ -43,13 +42,17 @@
         </div>
     </main>
     {{template "footer.html" .}}
-    <script type="module">
+    <script>
         const events = {{ .Events }};
 
-        let show_edit = window.localStorage.getItem("token") !== null;
         let immutable_past = {{ .ImmutablePast }};
         let check_auth_url = {{((.Router.Get "apiCheckAuth").URL "profile" .ProfileName).Path}};
-        if (show_edit) {
+
+        let show_edit = window.localStorage.getItem("token") !== null;
+        if(show_edit){
+            initEdit();
+        }
+        async function initEdit(){
             let response = await fetch(check_auth_url, {
                 method: "POST",
                 headers: {
@@ -61,6 +64,7 @@
                 // We have a token, but it's not valid anymore.
                 document.getElementById("error-message").innerHTML = "Der gespeicherte Token ist ungültig. Bearbeitung ist deaktiviert.";
                 document.getElementById("error-message-wrapper").classList.remove("d-none");
+                updateCalendar(currentDate);
             }
         }
 

--- a/cmd/ical-relay/templates/calendar.html
+++ b/cmd/ical-relay/templates/calendar.html
@@ -17,20 +17,25 @@
         </div>
         <!-- next and previous buttons -->
         <div class="row sticky-top bg-white">
-            <div class="col text-center">
-                <div class="d-inline-block h-75 align-bottom">
-                    <a class="btn btn-primary btn-sm" id="btn-prev">&lt;</a>
+            <div class="d-flex flex-row justify-content-between align-items-center">
+                <div>
+                    <a class="btn btn-primary btn-sm" id="btn-today">Heute</a>
                 </div>
-                <div class="d-inline-block vstack">
-                    <div>
-                        <span class="h5 text-center fw-bold m-0" id="current-date"></span>
+                <div class="d-flex align-items-center">
+                    <div class="d-inline-block">
+                        <a class="btn btn-primary btn-sm" id="btn-prev">&lt;</a>
                     </div>
-                    <div>
-                        <span class="h6">{{.ProfileName}}</span>
+                    <div class="d-inline-block vstack px-2">
+                        <div class="h5 text-center fw-bold m-0" id="current-date"></div>
+                        <div class="h6 text-center">{{.ProfileName}}</div>
+                    </div>
+                    <div class="d-inline-block">
+                        <a class="btn btn-primary btn-sm" id="btn-next">&gt;</a>
                     </div>
                 </div>
-                <div class="d-inline-block h-75 align-bottom">
-                    <a class="btn btn-primary btn-sm" id="btn-next">&gt;</a>
+                <div>
+                    <a class="btn btn-primary btn-sm" id="btn-week">Woche</a>
+                    <a class="btn btn-primary btn-sm" id="btn-month">Monat</a>
                 </div>
             </div>
         </div>
@@ -61,7 +66,30 @@
 
         let currentType = "month"; //month or week
 
+        function today(){
+            setSelectedDate(dayjs());
+        }
+        document.getElementById("btn-today").onclick = today;
+
+        function switchToWeek(){
+            currentType = "week";
+            if(currentDate.format("MM") === dayjs().format("MM")){
+                setSelectedDate(dayjs());
+            }else{
+                setSelectedDate(currentDate);
+            }
+        }
+        document.getElementById("btn-week").onclick = switchToWeek;
+
+        function switchToMonth(){
+            currentType = "month";
+            setSelectedDate(currentDate);
+        }
+        document.getElementById("btn-month").onclick = switchToMonth;
+
         function updateCalendar(date) {
+            document.getElementById("btn-week").hidden = currentType === "week";
+            document.getElementById("btn-month").hidden = currentType === "month";
             let calendarStart;
             let calendarEnd;
             if(currentType === "month"){
@@ -92,21 +120,25 @@
             }
         }
 
-        let currentDate = location.hash ? dayjs(location.hash.substring(1)) : dayjs().startOf(currentType);
-        if(location.hash.length > 8){
-            currentType = "week";
-            console.log("Enabling week view");
+        let currentDate;
+        function onHashChange(){
+            currentDate = location.hash ? dayjs(location.hash.substring(1)) : dayjs().startOf(currentType);
+            if(location.hash.length > 8){
+                currentType = "week";
+            }else{
+                currentType = "month";
+            }
+            updateCalendar(currentDate);
         }
-        updateCalendar(currentDate);
+        addEventListener("hashchange", onHashChange)
+        onHashChange();
 
         function setSelectedDate(date) {
-            currentDate = date;
             if(currentType === "month"){
                 window.location.hash = date.format("YYYY-MM");
             }else{
                 window.location.hash = date.format("YYYY-MM-DD");
             }
-            updateCalendar(date);
         }
 
         document.getElementById("btn-prev").addEventListener("click", () => {

--- a/cmd/ical-relay/templates/calendar.html
+++ b/cmd/ical-relay/templates/calendar.html
@@ -15,22 +15,22 @@
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
             </div>
         </div>
-        <!-- next and previous month buttons -->
+        <!-- next and previous buttons -->
         <div class="row sticky-top bg-white">
             <div class="col text-center">
                 <div class="d-inline-block h-75 align-bottom">
-                    <a class="btn btn-primary btn-sm" id="btn-prev-month">Previous Month</a>
+                    <a class="btn btn-primary btn-sm" id="btn-prev">&lt;</a>
                 </div>
                 <div class="d-inline-block vstack">
                     <div>
-                        <span class="h5 text-center fw-bold m-0" id="current-month"></span>
+                        <span class="h5 text-center fw-bold m-0" id="current-date"></span>
                     </div>
                     <div>
                         <span class="h6">{{.ProfileName}}</span>
                     </div>
                 </div>
                 <div class="d-inline-block h-75 align-bottom">
-                    <a class="btn btn-primary btn-sm" id="btn-next-month">Next Month</a>
+                    <a class="btn btn-primary btn-sm" id="btn-next">&gt;</a>
                 </div>
             </div>
         </div>
@@ -58,17 +58,30 @@
                 document.getElementById("error-message-wrapper").classList.remove("d-none");
             }
         }
+
+        let currentType = "month"; //month or week
+
         function updateCalendar(date) {
+            let calendarStart;
+            let calendarEnd;
+            if(currentType === "month"){
+                document.getElementById("current-date").innerHTML = currentDate.format("MMMM YYYY");
 
-            document.getElementById("current-month").innerHTML = currentMonth.format("MMMM YYYY");
+                calendarStart = date.day(0);
+                calendarEnd = date.add(4, "week").day(6);
+            }else{
+                document.getElementById("current-date").innerHTML = "KW"+currentDate.format(" w MMMM");
 
-            let calendar_start = date.day(0);
-            let calendar_end = date.add(4, "week").day(6);
+                calendarStart = date.startOf("week").subtract(1, "day");
+                calendarEnd = calendarStart.add(1, "week");
+            }
+            console.log(calendarStart);
+            console.log(calendarEnd);
             let calendar = document.getElementById("calendar");
             calendar.innerHTML = "";
             let row;
-            for (let date = calendar_start; date <= calendar_end; date = date.add(1, "day")) {
-                if (date.day() == 0) {
+            for (let date = calendarStart; date <= calendarEnd; date = date.add(1, "day")) {
+                if (date.day() === 0) {
                     row = document.createElement("div");
                     row.classList.add("row");
                     calendar.appendChild(row);
@@ -79,20 +92,28 @@
             }
         }
 
-        function setSelectedMonth(date) {
-            currentMonth = date;
-            window.location.hash = currentMonth.format("YYYY-MM");
+        let currentDate = location.hash ? dayjs(location.hash.substring(1)) : dayjs().startOf(currentType);
+        if(location.hash.length > 8){
+            currentType = "week";
+            console.log("Enabling week view");
+        }
+        updateCalendar(currentDate);
+
+        function setSelectedDate(date) {
+            currentDate = date;
+            if(currentType === "month"){
+                window.location.hash = date.format("YYYY-MM");
+            }else{
+                window.location.hash = date.format("YYYY-MM-DD");
+            }
             updateCalendar(date);
         }
 
-        let currentMonth = location.hash ? dayjs(location.hash.substring(1)) : dayjs().startOf("month");
-        updateCalendar(currentMonth);
-
-        document.getElementById("btn-prev-month").addEventListener("click", () => {
-            setSelectedMonth(currentMonth.subtract(1, "month").startOf("month"));
+        document.getElementById("btn-prev").addEventListener("click", () => {
+            setSelectedDate(currentDate.subtract(1, currentType).startOf(currentType));
         });
-        document.getElementById("btn-next-month").addEventListener("click", () => {
-            setSelectedMonth(currentMonth.add(1, "month").startOf("month"));
+        document.getElementById("btn-next").addEventListener("click", () => {
+            setSelectedDate(currentDate.add(1, currentType).startOf(currentType));
         });
     </script>
 </body>

--- a/cmd/ical-relay/templates/calendar.html
+++ b/cmd/ical-relay/templates/calendar.html
@@ -64,7 +64,7 @@
             }
         }
 
-        let currentType = "month"; //month or week
+        let currentType = "week"; //month or week
 
         function today(){
             setSelectedDate(dayjs());
@@ -122,12 +122,14 @@
 
         let currentDate;
         function onHashChange(){
-            currentDate = location.hash ? dayjs(location.hash.substring(1)) : dayjs().startOf(currentType);
-            if(location.hash.length > 8){
-                currentType = "week";
-            }else{
-                currentType = "month";
+            if(location.hash){
+                if(location.hash.length > 8){
+                    currentType = "week";
+                }else{
+                    currentType = "month";
+                }
             }
+            currentDate = location.hash ? dayjs(location.hash.substring(1)) : dayjs().startOf(currentType);
             updateCalendar(currentDate);
         }
         addEventListener("hashchange", onHashChange)

--- a/cmd/ical-relay/templates/calendar.html
+++ b/cmd/ical-relay/templates/calendar.html
@@ -68,7 +68,8 @@
             }
         }
 
-        let currentType = "week"; //month or week
+        //month or week
+        let currentType = localStorage.getItem("viewType") == null ? "week" : localStorage.getItem("viewType");
 
         function today(){
             setSelectedDate(dayjs());
@@ -92,6 +93,7 @@
         document.getElementById("btn-month").onclick = switchToMonth;
 
         function updateCalendar(date) {
+            localStorage.setItem("viewType", currentType);
             document.getElementById("btn-week").hidden = currentType === "week";
             document.getElementById("btn-month").hidden = currentType === "month";
             let calendarStart;

--- a/cmd/ical-relay/templates/head.html
+++ b/cmd/ical-relay/templates/head.html
@@ -5,6 +5,12 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" integrity="sha256-wLz3iY/cO4e6vKZ4zRmo4+9XDpMcgKOvv/zEU3OMlRo=" crossorigin="anonymous">
 <script src="https://cdn.jsdelivr.net/npm/dayjs@1.11.7/dayjs.min.js" integrity="sha256-EfJOqCcshFS/2TxhArURu3Wn8b/XDA4fbPWKSwZ+1B8=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/dayjs@1.11.7/locale/de.js" integrity="sha256-NZbeygtRRe4BTHc5nqF1RLqJgaL7hwYJfYLxDTVJWZw=" crossorigin="anonymous"></script>
-<script>dayjs.locale("de")</script>
+<script src="https://cdn.jsdelivr.net/npm/dayjs@1.11.7/plugin/advancedFormat.js" integrity="sha256-b5ymCcSvYPKgMDPnLexXFPT457JAOBk0BA9UegKCRj8=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/dayjs@1.11.7/plugin/weekOfYear.js" integrity="sha256-+36bSyE7K3KU/VI2u0h4ti5ogpLPLAd0Xwx/8Adigz8=" crossorigin="anonymous"></script>
+<script>
+    dayjs.locale("de");
+    dayjs.extend(window.dayjs_plugin_advancedFormat);
+    dayjs.extend(window.dayjs_plugin_weekOfYear);
+</script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css" integrity="sha256-FdatTf20PQr/rWg+cAKfl6j4/IY3oohFAJ7gVC3M34E=" crossorigin="anonymous">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ttskch/select2-bootstrap4-theme@1.5.2/dist/select2-bootstrap4.min.css" integrity="sha256-h7vy42BP4MtLE0udIyBuOEoB8nJI2iLaiOJEgO5Ykp0=" crossorigin="anonymous">

--- a/cmd/ical-relay/templates/index.html
+++ b/cmd/ical-relay/templates/index.html
@@ -6,7 +6,7 @@
         // Because this is potentially a redirect, we run it as soon as possible
         let stored_profile = window.localStorage.getItem('profile');
         if (stored_profile !== null) {
-            let profile_url = ({{((.Router.Get "monthlyView").URL "profile" "%PROFILE%").Path}}).replace('%PROFILE%', encodeURIComponent(stored_profile));
+            let profile_url = ({{((.Router.Get "calendarView").URL "profile" "%PROFILE%").Path}}).replace('%PROFILE%', encodeURIComponent(stored_profile));
             window.location.href =  profile_url;
         }
     </script>

--- a/cmd/ical-relay/templates/settings.html
+++ b/cmd/ical-relay/templates/settings.html
@@ -43,7 +43,7 @@
             document.getElementById("token").value = localStorage.getItem("token");
         }
         function redirect_to_profile(profile_name) {
-            let profile_url = ({{((.Router.Get "monthlyView").URL "profile" "%PROFILE%").Path}}).replace('%PROFILE%', encodeURIComponent(profile_name));
+            let profile_url = ({{((.Router.Get "calendarView").URL "profile" "%PROFILE%").Path}}).replace('%PROFILE%', encodeURIComponent(profile_name));
             window.location.href =  profile_url;
         }
         function handleSaveSettings(e) {

--- a/cmd/ical-relay/templates/static/js/calendar.js
+++ b/cmd/ical-relay/templates/static/js/calendar.js
@@ -73,6 +73,13 @@ function getDayVStack(date, events, show_edit = false, edit_enabled = true) {
     day_vstack.classList.add("vstack", "col-md-4", "col-xl-2", "pt-2", "day-column", "mb-3");
     let day_title = document.createElement("h5");
     day_title.classList.add("fw-semibold", "text-center", "m-0");
+    if(currentType === "month"){
+        day_title.role = "button";
+        day_title.onclick = function(){
+            currentType = "week";
+            setSelectedDate(date);
+        }
+    }
     if (date.isSame(dayjs(), "day")) {
         day_title.classList.add("today");
     }

--- a/cmd/ical-relay/templates/static/js/calendar.js
+++ b/cmd/ical-relay/templates/static/js/calendar.js
@@ -94,14 +94,14 @@ function getDayVStack(date, events, show_edit = false, edit_enabled = true) {
         });
         for (let event of day_events) {
             let card = getEventCard(event, show_edit, edit_enabled);
-            if(date.format("MM") != currentMonth){
+            if(currentType === "month" && date.format("MM") != currentMonth){
                 card.style.backgroundColor = "#e1e6ea";
             }
             day_vstack.appendChild(card);
         }
     } else {
         let card = getEmptyCard();
-        if(date.format("MM") != currentMonth){
+        if(currentType === "month" && date.format("MM") != currentMonth){
             card.style.backgroundColor = "#e1e6ea";
         }else{
             card.classList.add("bg-light");


### PR DESCRIPTION
Breaks current bookmarks (dropped /monthly of url), TBD: `/profileName` instead of `/view/profileName`
Currently only accessible by hash (#YYYY-MM-DD)

ToDo:
- [x] Add weekly/monthly switch (=button) on the right side (-> week switch should go to current week it is in the month displayed, otherwise to the first one in a month)
- [x] Default to week view ~on mobile~ when no hash is present
- [x] handle hash update events
- [x] save last view type month / week in localStorage
- [ ] Introduce #currentMonth, #currentWeek (tbd: naming, drop?)
- [x] Somewhat unrelated: "today" button
- [ ] Somewhat unrelated: "today" button scrolls to current day
- [x] Clicking on a day (~maybe~ only the header of it) on the month view should go into the weekly view
- [x] Do not shade days from a different month in week view
