### PR TITLE
fix(frontend): Handle missing properties in javascript

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# v2.0.0-beta.6.3
+
+- Fix Edit view crashing for events without a `SUMMARY` or `LOCATION` property
+
 # v2.0.0-beta.6.2
 
 - Fix config.go getNotifier(): Starting with existing DB assigned notifiers to nil map

--- a/cmd/ical-relay/main.go
+++ b/cmd/ical-relay/main.go
@@ -14,7 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var version = "2.0.0-beta.6.2"
+var version = "2.0.0-beta.6.3"
 
 var configPath string
 var conf Config

--- a/cmd/ical-relay/templates/edit.html
+++ b/cmd/ical-relay/templates/edit.html
@@ -51,8 +51,8 @@
     <script>
         const profileName = {{.ProfileName }};
         const uid = {{(.Event.GetProperty "UID").Value}};
-        const originalSummary = {{(.Event.GetProperty "SUMMARY").Value}};
-        const originalLocation = {{(.Event.GetProperty "LOCATION").Value}};
+        const originalSummary = {{ if .Event.GetProperty "SUMMARY" }}{{(.Event.GetProperty "SUMMARY").Value}}{{ else }} ""{{ end }};
+        const originalLocation = {{ if .Event.GetProperty "LOCATION" }}{{(.Event.GetProperty "LOCATION").Value}}{{ else }} ""{{ end }};
         const originalStart = dayjs({{(.Event.GetStartAt).Format "2006-01-02T15:04:05Z07:00"}});
         const originalEnd = dayjs({{(.Event.GetEndAt).Format "2006-01-02T15:04:05Z07:00"}});
         const originalDescription = {{ if .Event.GetProperty "DESCRIPTION" }}{{ (.Event.GetProperty "DESCRIPTION").Value }}{{ else }} ""{{ end }};


### PR DESCRIPTION
The frontend edit view rendered correctly but the javascript crashed, so edit functionality did not work.