### PR TITLE
fix(frontend): check auth only with saved token (#199)

### DIFF
--- a/cmd/ical-relay/templates/footer.html
+++ b/cmd/ical-relay/templates/footer.html
@@ -16,7 +16,7 @@
 	initSelect2('#nav-profile');
     async function displayAdminIfSuperAuth(){
         try{
-            if(await API.get("checkSuperAuth") === "ok"){
+            if(window.localStorage.getItem("token") !== null && await API.get("checkSuperAuth") === "ok"){
                 document.querySelector("#nav-admin-link").classList.remove("d-none");
             }
         }catch(APIError){}


### PR DESCRIPTION
This simply only requests the `checkSuperAuth` endpoint if a token is saved in local storage.
If no token is saved in local storage, it is unneccessary to check for authorization.

Closes #199