### PR TITLE
fix(DB): use correct key to select filters in dbReadProfile

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 2.0.0-beta.7.4
+
+- Fix critical bug in Databse query for Rule Filters
+
 # 2.0.0-beta.7.3
 
 - Implement PUT /api/profiles/<profile> (editProfile) for DB

--- a/cmd/ical-relay/database.go
+++ b/cmd/ical-relay/database.go
@@ -203,7 +203,7 @@ JOIN profile_sources ps ON id = ps.source WHERE ps.profile = $1`,
 		rule.Action = actionParameters
 
 		var dbFilters []dbFilter
-		err = db.Select(&dbFilters, "SELECT type, parameters FROM filter WHERE id = $1", dbRule.Id)
+		err = db.Select(&dbFilters, "SELECT type, parameters FROM filter WHERE rule = $1", dbRule.Id)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/ical-relay/main.go
+++ b/cmd/ical-relay/main.go
@@ -13,7 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var version = "2.0.0-beta.7.3"
+var version = "2.0.0-beta.7.4"
 
 var configPath string
 var conf Config


### PR DESCRIPTION
A pretty blatant coding error preventing the fetching of multiple filters from the db and breaking everything as soon as a single rule in the database had more than two filters.

This went undetected for so long, because multiple filters per rule were not used in the current deployments.

Fixes #237