### PR TITLE
fix: Use explicit getters and setters for common properties

### DIFF
--- a/cmd/ical-relay/handlers.go
+++ b/cmd/ical-relay/handlers.go
@@ -224,15 +224,8 @@ func getEventsByDay(calendar *ics.Calendar, profileName string) calendarDataByDa
 			log.Errorln(err)
 		}
 
-		summary := event.GetProperty("SUMMARY")
-		var summarytext string
-		if summary != nil {
-			summarytext = summary.Value
-		} else {
-			summarytext = ""
-		}
 		data := eventData{
-			"title":      summarytext,
+			"title":      event.GetSummary(),
 			"start":      startTime,
 			"show_start": showStart,
 			"end":        endTime,
@@ -240,12 +233,11 @@ func getEventsByDay(calendar *ics.Calendar, profileName string) calendarDataByDa
 			"id":         event.GetProperty("UID").Value,
 			"edit_url":   edit_url.String(),
 		}
-		description := event.GetProperty("DESCRIPTION")
-		if description != nil {
-			data["description"] = description.Value
+		if event.GetProperty("DESCRIPTION") != nil {
+			data["description"] = event.GetDescription()
 		}
 		if event.GetProperty("LOCATION") != nil {
-			data["location"] = event.GetProperty("LOCATION").Value
+			data["location"] = event.GetLocation()
 		}
 		startDay := time.Date(startTime.Year(), startTime.Month(), startTime.Day(), 0, 0, 0, 0, time.UTC)
 		endDay := time.Date(endTime.Year(), endTime.Month(), endTime.Day(), 0, 0, 0, 0, time.UTC)

--- a/cmd/ical-relay/templates/edit.html
+++ b/cmd/ical-relay/templates/edit.html
@@ -8,8 +8,7 @@
   {{template "nav.html" .}}
   <main class="container">
     <h1 class="mb-3">
-      {{ if .Event.GetProperty "SUMMARY" }}{{(.Event.GetProperty
-      "SUMMARY").Value}}{{ end }} bearbeiten
+      {{ if .Event.GetProperty "SUMMARY" }}{{.Event.GetSummary }}{{ end }} bearbeiten
     </h1>
     <div class="alert alert-danger" id="edit-error" style="display: none">
       Es ist ein Fehler aufgetreten! Sind Sie eingeloggt?
@@ -19,16 +18,14 @@
         <label for="summary" class="col-sm-1 col-form-label">Titel</label>
         <div class="col-sm-11">
           <input type="text" class="form-control" id="summary" name="summary"
-          value="{{ if .Event.GetProperty "SUMMARY" }}{{(.Event.GetProperty
-          "SUMMARY").Value}}{{ end }}">
+          value="{{ if .Event.GetProperty "SUMMARY" }}{{ .Event.GetSummary }}{{ end }}">
         </div>
       </div>
       <div class="row mb-3">
         <label for="location" class="col-sm-1 col-form-label">Ort</label>
         <div class="col-sm-11">
           <input type="text" class="form-control" id="location" name="location"
-          value="{{ if .Event.GetProperty "LOCATION" }}{{(.Event.GetProperty
-          "LOCATION").Value}}{{ end }}">
+          value="{{ if .Event.GetProperty "LOCATION" }}{{ .Event.GetLocation }}{{ end }}">
         </div>
       </div>
       <div class="row mb-3">
@@ -62,7 +59,7 @@
             name="description"
             rows="1"
           >
-{{ if .Event.GetProperty "DESCRIPTION" }}{{(.Event.GetProperty "DESCRIPTION").Value}}{{ end }}</textarea
+{{ if .Event.GetProperty "DESCRIPTION" }}{{ .Event.GetDescription }}{{ end }}</textarea
           >
         </div>
       </div>
@@ -78,11 +75,11 @@
   <script>
     const profileName = {{.ProfileName }};
     const uid = {{(.Event.GetProperty "UID").Value}};
-    const originalSummary = {{ if .Event.GetProperty "SUMMARY" }}{{(.Event.GetProperty "SUMMARY").Value}}{{ else }} ""{{ end }};
-    const originalLocation = {{ if .Event.GetProperty "LOCATION" }}{{(.Event.GetProperty "LOCATION").Value}}{{ else }} ""{{ end }};
+    const originalSummary = {{ if .Event.GetProperty "SUMMARY" }}{{ .Event.GetSummary }}{{ else }} ""{{ end }};
+    const originalLocation = {{ if .Event.GetProperty "LOCATION" }}{{ .Event.GetLocation }}{{ else }} ""{{ end }};
     const originalStart = dayjs({{(.Event.GetStartAt).Format "2006-01-02T15:04:05Z07:00"}});
     const originalEnd = dayjs({{(.Event.GetEndAt).Format "2006-01-02T15:04:05Z07:00"}});
-    const originalDescription = {{ if .Event.GetProperty "DESCRIPTION" }}{{ (.Event.GetProperty "DESCRIPTION").Value }}{{ else }} ""{{ end }};
+    const originalDescription = {{ if .Event.GetProperty "DESCRIPTION" }}{{ .Event.GetDescription  }}{{ else }} ""{{ end }};
     document.getElementById("start").value = originalStart.format("YYYY-MM-DDTHH:mm");
     document.getElementById("end").value = originalEnd.format("YYYY-MM-DDTHH:mm");
 

--- a/pkg/modules/actions.go
+++ b/pkg/modules/actions.go
@@ -66,13 +66,13 @@ func ActionEdit(cal *ics.Calendar, indices []int, params map[string]string) erro
 				}
 				switch params["overwrite"] {
 				case "false":
-					event.SetProperty(ics.ComponentPropertySummary, event.GetProperty(ics.ComponentPropertySummary).Value+"; "+params["new-summary"])
+					event.SetSummary(event.GetSummary() + "; " + params["new-summary"])
 				case "fillempty":
 					if event.GetProperty(ics.ComponentPropertySummary).Value == "" {
-						event.SetProperty(ics.ComponentPropertySummary, params["new-summary"])
+						event.SetSummary(params["new-summary"])
 					}
 				case "true":
-					event.SetProperty(ics.ComponentPropertySummary, params["new-summary"])
+					event.SetSummary(params["new-summary"])
 				}
 				log.Debug("Changed summary to " + event.GetProperty(ics.ComponentPropertySummary).Value)
 			}
@@ -83,13 +83,13 @@ func ActionEdit(cal *ics.Calendar, indices []int, params map[string]string) erro
 				}
 				switch params["overwrite"] {
 				case "false":
-					event.SetProperty(ics.ComponentPropertyDescription, event.GetProperty(ics.ComponentPropertyDescription).Value+"; "+params["new-description"])
+					event.SetDescription(event.GetDescription() + "; " + params["new-description"])
 				case "fillempty":
 					if event.GetProperty(ics.ComponentPropertyDescription).Value == "" {
-						event.SetProperty(ics.ComponentPropertyDescription, params["new-description"])
+						event.SetDescription(params["new-description"])
 					}
 				case "true":
-					event.SetProperty(ics.ComponentPropertyDescription, params["new-description"])
+					event.SetDescription(params["new-description"])
 				}
 				log.Debug("Changed description to " + event.GetProperty(ics.ComponentPropertyDescription).Value)
 			}
@@ -100,13 +100,13 @@ func ActionEdit(cal *ics.Calendar, indices []int, params map[string]string) erro
 				}
 				switch params["overwrite"] {
 				case "false":
-					event.SetProperty(ics.ComponentPropertyLocation, event.GetProperty(ics.ComponentPropertyLocation).Value+"; "+params["new-location"])
+					event.SetLocation(event.GetLocation() + "; " + params["new-location"])
 				case "fillempty":
 					if event.GetProperty(ics.ComponentPropertyLocation).Value == "" {
-						event.SetProperty(ics.ComponentPropertyLocation, params["new-location"])
+						event.SetLocation(params["new-location"])
 					}
 				case "true":
-					event.SetProperty(ics.ComponentPropertyLocation, params["new-location"])
+					event.SetLocation(params["new-location"])
 				}
 				log.Debug("Changed location to " + event.GetProperty(ics.ComponentPropertyLocation).Value)
 			}

--- a/pkg/modules/filters.go
+++ b/pkg/modules/filters.go
@@ -52,19 +52,19 @@ func FilterRegex(cal *ics.Calendar, params map[string]string) ([]int, error) {
 			switch params["target"] {
 			case "summary":
 				if event.GetProperty(ics.ComponentPropertySummary) != nil {
-					target = event.GetProperty(ics.ComponentPropertySummary).Value
+					target = event.GetSummary()
 				} else {
 					continue
 				}
 			case "description":
 				if event.GetProperty(ics.ComponentPropertyDescription) != nil {
-					target = event.GetProperty(ics.ComponentPropertyDescription).Value
+					target = event.GetDescription()
 				} else {
 					continue
 				}
 			case "location":
 				if event.GetProperty(ics.ComponentPropertyLocation) != nil {
-					target = event.GetProperty(ics.ComponentPropertyLocation).Value
+					target = event.GetLocation()
 				} else {
 					continue
 				}


### PR DESCRIPTION
This ensures values are correctly escaped.

When setting properties using SetDescription, it is escaped. This ensures a well-formed iCal file. Using GetDescription returns the unescaped string, resulting in a well-rendered frontend.

**This is blocked by JM-Lemmi/golang-ical#7**. Merging before that PR is merged, and then incorporated back into this repository via the submodule, **will break things**.