### PR TITLE
fixes issues with calendars using a global timezone

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -106,6 +106,7 @@ jobs:
           version: ${{ github.ref }} # refs/tags/v*.*.*
           arch: '${{ matrix.arch }}'
           desc: 'Relay ical urls and edit them on the fly with different modules.'
+          depends: 'tzdata'
       - uses: actions/upload-artifact@v3
         with:
           name: ical-relay_${{ matrix.arch }}.deb

--- a/cmd/ical-relay/Dockerfile
+++ b/cmd/ical-relay/Dockerfile
@@ -10,7 +10,7 @@ RUN go build -o ./cmd/ical-relay/ical-relay ./cmd/ical-relay/
 
 FROM alpine AS run
 
-RUN apk --update add ca-certificates curl
+RUN apk --update add ca-certificates curl tzdata
 COPY --from=build /app/cmd/ical-relay/ical-relay /usr/bin/ical-relay
 
 RUN mkdir -p /etc/ical-relay/calstore/

--- a/cmd/ical-relay/profiles.go
+++ b/cmd/ical-relay/profiles.go
@@ -68,6 +68,7 @@ func getProfileCalendar(profile datastore.Profile, profileName string) (*ics.Cal
 				// first source gets assigned to base calendar
 				log.Debug("Loading source ", s, " as base calendar")
 				calendar, err = getSource(s)
+				helpers.FixTimezone(calendar)
 				if err != nil {
 					return nil, err
 				}
@@ -75,6 +76,7 @@ func getProfileCalendar(profile datastore.Profile, profileName string) (*ics.Cal
 				// all other calendars only load events
 				log.Debug("Loading source ", s, " as additional calendar")
 				ncalendar, err = getSource(s)
+				helpers.FixTimezone(ncalendar)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
fixes issues with calendars using a global timezone instead of specifing it in every VEvent:
- implement a helper function which reads the TIMEZONE or X-WR-TIMEZONE property from the calendar and inserts it into every VEvent where no timezone is set
- add tzdata package to docker image to support timezones like Europe/Berlin