### PR TITLE
fix(relay): do not add XRW-TIMEZONE to UTC timestamps

### DIFF
--- a/pkg/modules/actions.go
+++ b/pkg/modules/actions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 	"time"
 
 	ics "github.com/arran4/golang-ical"
@@ -256,6 +257,10 @@ func ActionXWRTimezoneToVTimezone(cal *ics.Calendar) error {
 	for _, event := range cal.Events() {
 		for _, prop := range event.Properties {
 			if prop.IANAToken == "DTSTART" || prop.IANAToken == "DTEND" {
+				// skip further checks if value ends with Z, since that indicates UTC value
+				if strings.HasSuffix(prop.Value, "Z") {
+					continue
+				}
 				// set timezone only if no timezone is already set
 				if _, ok := prop.ICalParameters["TZID"]; !ok {
 					prop.ICalParameters["TZID"] = []string{property.Value}


### PR DESCRIPTION
This change skips adding the XWR-TIMEZONE to events with UTC timestamps.
That resulted in events being wrongly displayed in the ics export (e.g. in a google calendar)

This fix applies to all existing events which will be loaded from any source.

Tested by importing a database with a wrongly displayed event, exporting the ics using this version and imported it into Google calendar.

fixes #268