### PR TITLE
fix(datastore): adjust sql query to load filters

### DIFF
--- a/pkg/datastore/database.go
+++ b/pkg/datastore/database.go
@@ -238,7 +238,7 @@ JOIN profile_sources ps ON id = ps.source WHERE ps.profile = $1`,
 		rule.Action = actionParameters
 
 		var dbFilters []dbFilter
-		err = db.Select(&dbFilters, "SELECT type, parameters FROM filter WHERE id = $1", dbRule.Id)
+		err = db.Select(&dbFilters, "SELECT type, parameters FROM filter WHERE rule = $1", dbRule.Id)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
The filters were loaded using the row id of the filters (filter ID) which coincidentally matched the rule ID. As soon as the length of the rule and filter table differ, this method will return empty filters for loaded rules and the customizations to the events will not be shown anymore.