### PR TITLE
fix: change edit and new event to always include tzid

### DIFF
--- a/cmd/ical-relay/api.go
+++ b/cmd/ical-relay/api.go
@@ -402,12 +402,12 @@ func newentryjsonApiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		var tz *time.Location
 		if tz_str, ok := eventjson["timezone"]; !ok {
-			requestLogger.Warnln("No timezone given in new event payload. Will use locale as fallback")
+			requestLogger.Warnln("No timezone given in new event payload. Will use local as fallback")
 			tz = time.Local
 		} else {
 			tz, err = time.LoadLocation(tz_str)
 			if err != nil {
-				requestLogger.Errorln("Unparseable timezone given in new event payload. Will use locale as fallback", tz_str)
+				requestLogger.Errorln("Unparseable timezone given in new event payload. Will use local as fallback", tz_str)
 				tz = time.Local
 			} else {
 				// Since GoLang's time.Location().String() is not consistent with its output, we use the user-prvided timezone here,

--- a/cmd/ical-relay/api.go
+++ b/cmd/ical-relay/api.go
@@ -391,11 +391,29 @@ func newentryjsonApiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		event := ics.NewEvent(uuid.New().String() + "@" + url)
 
+		// create calendar
+		cal := ics.NewCalendar()
+
 		if eventjson["summary"] != "" {
 			event.SetSummary(eventjson["summary"])
 		}
 		if eventjson["location"] != "" {
 			event.SetLocation(eventjson["location"])
+		}
+		var tz *time.Location
+		if tz_str, ok := eventjson["timezone"]; !ok {
+			requestLogger.Warnln("No timezone given in new event payload. Will use locale as fallback")
+			tz = time.Local
+		} else {
+			tz, err = time.LoadLocation(tz_str)
+			if err != nil {
+				requestLogger.Errorln("Unparseable timezone given in new event payload. Will use locale as fallback", tz_str)
+				tz = time.Local
+			} else {
+				// Since GoLang's time.Location().String() is not consistent with its output, we use the user-prvided timezone here,
+				// as it was successfully parsed by GoLang
+				cal.AddTimezone(eventjson["timezone"])
+			}
 		}
 		if eventjson["start"] != "" {
 			start, err := time.Parse(time.RFC3339, eventjson["start"])
@@ -404,7 +422,7 @@ func newentryjsonApiHandler(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
-			event.SetStartAt(start)
+			event.SetStartWithTimezoneAt(start.In(tz), tz)
 		} else {
 			requestLogger.Errorln("No start time given!")
 			http.Error(w, "No start time given!", http.StatusBadRequest)
@@ -417,7 +435,7 @@ func newentryjsonApiHandler(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
-			event.SetEndAt(end)
+			event.SetEndWithTimezoneAt(end.In(tz), tz)
 		} else {
 			requestLogger.Errorln("No end time given!")
 			http.Error(w, "No end time given!", http.StatusBadRequest)
@@ -427,8 +445,6 @@ func newentryjsonApiHandler(w http.ResponseWriter, r *http.Request) {
 			event.SetDescription(eventjson["description"])
 		}
 
-		// create calendar
-		cal := ics.NewCalendar()
 		cal.AddVEvent(event)
 
 		// convert calendar to base64

--- a/cmd/ical-relay/templates/edit.html
+++ b/cmd/ical-relay/templates/edit.html
@@ -107,11 +107,11 @@
         }
         let start = dayjs(document.getElementById("start").value);
         if (!start.isSame(originalStart)) {
-            event.start = start.toISOString();
+            event.start = start.format("YYYY-MM-DDTHH:mm:ssZ");
         }
         let end = dayjs(document.getElementById("end").value);
         if (!end.isSame(originalEnd)) {
-            event.end = end.toISOString();
+            event.end = end.format("YYYY-MM-DDTHH:mm:ssZ");
         }
         if (document.getElementById("description").value !== originalDescription) {
             event.description = document.getElementById("description").value;

--- a/cmd/ical-relay/templates/newevent.html
+++ b/cmd/ical-relay/templates/newevent.html
@@ -90,10 +90,11 @@
         event.summary = document.getElementById("summary").value;
         event.location = document.getElementById("location").value;
         let start = dayjs(document.getElementById("start").value);
-        event.start = start.toISOString();
+        event.start = start.format("YYYY-MM-DDTHH:mm:ssZ");
         let end = dayjs(document.getElementById("end").value);
-        event.end = end.toISOString();
+        event.end = end.format("YYYY-MM-DDTHH:mm:ssZ");
         event.description = document.getElementById("description").value;
+        event.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
 
         if (Object.keys(event).length === 0) {
             return_to_prev();

--- a/pkg/modules/actions.go
+++ b/pkg/modules/actions.go
@@ -112,19 +112,27 @@ func ActionEdit(cal *ics.Calendar, indices []int, params map[string]string) erro
 				log.Debug("Changed location to " + event.GetProperty(ics.ComponentPropertyLocation).Value)
 			}
 			if _, ok := params["new-start"]; ok {
+				prev_start, err := event.GetStartAt()
+				if err != nil {
+					return fmt.Errorf("expected to be able to load previous start time: %s", err.Error())
+				}
 				start, err := time.Parse(time.RFC3339, params["new-start"])
 				if err != nil {
 					return fmt.Errorf("invalid start time: %s", err.Error())
 				}
-				event.SetStartAt(start)
+				event.SetStartWithTimezoneAt(start.In(prev_start.Location()), prev_start.Location())
 				log.Debug("Changed start to " + params["new-start"])
 			}
 			if _, ok := params["new-end"]; ok {
+				prev_end, err := event.GetStartAt()
+				if err != nil {
+					return fmt.Errorf("expected to be able to load previous end time: %s", err.Error())
+				}
 				end, err := time.Parse(time.RFC3339, params["new-end"])
 				if err != nil {
 					return fmt.Errorf("invalid end time: %s", err.Error())
 				}
-				event.SetEndAt(end)
+				event.SetEndWithTimezoneAt(end.In(prev_end.Location()), prev_end.Location())
 				log.Debug("Changed end to " + params["new-end"])
 			}
 


### PR DESCRIPTION
This causes any new and edited event to always have TZIDs in the generated iCal file, which fixes #274.

Edited events keep the previous TZID (i.e. previous start date TZID -> new start date TZID, analogous for end date), whilst new events use the TZID of the user's browser (with time.Locale as fallback) and also include it in the generated iCal as VTimezone.