### PR TITLE
feat(relay): allow same-day event editing with immutable past

### DIFF
--- a/cmd/ical-relay/profiles.go
+++ b/cmd/ical-relay/profiles.go
@@ -231,10 +231,11 @@ func getProfileCalendar(profile datastore.Profile, profileName string) (*ics.Cal
 }
 
 // Delete Helper funtion for immutable past.
-// Will delete events from the calendar either before or after now.
-// timeframes: "before": delete up till now, "after" delete everything after now
+// Will delete events from the calendar either before or after the start of today.
+// This allows events from the current day to remain editable even if they have already passed.
+// timeframes: "before": delete up till start of today, "after" delete everything after start of today
 func ImmutablePastDelete(cal *ics.Calendar, timeframe string) error {
-	indices, err := modules.CallFilter(modules.Filters["timeframe"], cal, map[string]string{timeframe: "now"})
+	indices, err := modules.CallFilter(modules.Filters["timeframe"], cal, map[string]string{timeframe: "today"})
 	if err != nil {
 		return err
 	}

--- a/cmd/ical-relay/templates/static/js/calendar.js
+++ b/cmd/ical-relay/templates/static/js/calendar.js
@@ -101,7 +101,7 @@ function getDayVStack(date, events, show_edit = false, immutable_past = true) {
             return dayjs(a.start).diff(dayjs(b.start));
         });
         for (let event of day_events) {
-            let edit_enabled = !immutable_past || dayjs(event.start).isAfter(dayjs());
+            let edit_enabled = !immutable_past || !dayjs(event.start).isBefore(dayjs().startOf('day'));
             let card = getEventCard(event, show_edit, edit_enabled);
             if(currentType === "month" && date.format("MM") != currentMonth){
                 card.style.backgroundColor = "#e1e6ea";

--- a/documentation/filters.md
+++ b/documentation/filters.md
@@ -15,7 +15,7 @@ This can match multiple events, for example with repeating events.
 
 #### timeframe
 
-* `after`, `before`. At least one is mandatory. Uses max time, if none is given. Can also be set to "now".
+* `after`, `before`. At least one is mandatory. Uses max time, if none is given. Can also be set to "now" (current time) or "today" (start of the current day, 00:00:00 local time). The "today" keyword is used by `immutable_past` to keep events from the current day editable even after they have passed.
 
 #### duplicates
 

--- a/pkg/modules/filters.go
+++ b/pkg/modules/filters.go
@@ -117,6 +117,7 @@ func FilterId(cal *ics.Calendar, params map[string]string) ([]int, error) {
 // Parameters: either "after" or "before" mandatory
 // Format is RFC3339: "2006-01-02T15:04:05Z"
 // or "now" for current time
+// or "today" for start of the current day (00:00:00 local time)
 // TODO: implement RRULE compatibility from v1.3.1
 func FilterTimeframe(cal *ics.Calendar, params map[string]string) ([]int, error) {
 	var indices []int
@@ -133,6 +134,9 @@ func FilterTimeframe(cal *ics.Calendar, params map[string]string) ([]int, error)
 		after = time.Time{}
 	} else if params["after"] == "now" {
 		after = time.Now()
+	} else if params["after"] == "today" {
+		now := time.Now()
+		after = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	} else {
 		after, err = time.Parse(time.RFC3339, params["after"])
 		if err != nil {
@@ -144,6 +148,9 @@ func FilterTimeframe(cal *ics.Calendar, params map[string]string) ([]int, error)
 		before = time.Unix(1<<63-1-int64((1969*365+1969/4-1969/100+1969/400)*24*60*60), 999999999)
 	} else if params["before"] == "now" {
 		before = time.Now()
+	} else if params["before"] == "today" {
+		now := time.Now()
+		before = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	} else {
 		before, err = time.Parse(time.RFC3339, params["before"])
 		if err != nil {


### PR DESCRIPTION
Change immutable past cutoff from current time to start of today (00:00). This allows events from the current day to remain editable even after their start time has passed.

- Add 'today' keyword to FilterTimeframe (backend)
- Update ImmutablePastDelete to use 'today' instead of 'now'
- Fix frontend edit button to use start-of-day check
- Update documentation for timeframe filter